### PR TITLE
feat(experiments): add gpt-5.5-pro

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ pnpm run export-results -- claude-opus-4.6       # Export specific experiment
 | `devstral-2` | `opencode` | `vercel/mistral/devstral-2` |
 | `gpt-5.3-codex-xhigh` | `codex` | `gpt-5.3-codex-api-preview?reasoningEffort=xhigh` |
 | `gpt-5.4-xhigh` | `vercel-ai-gateway/codex` | `openai/gpt-5.4?reasoningEffort=xhigh` |
+| `gpt-5.5-xhigh` | `codex` | `gpt-5.5?reasoningEffort=xhigh` |
 
 ## Eval structure
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ pnpm run export-results -- claude-opus-4.6       # Export specific experiment
 | `devstral-2` | `opencode` | `vercel/mistral/devstral-2` |
 | `gpt-5.3-codex-xhigh` | `codex` | `gpt-5.3-codex-api-preview?reasoningEffort=xhigh` |
 | `gpt-5.4-xhigh` | `vercel-ai-gateway/codex` | `openai/gpt-5.4?reasoningEffort=xhigh` |
-| `gpt-5.5-xhigh` | `codex` | `gpt-5.5?reasoningEffort=xhigh` |
+| `gpt-5.5-pro` | `vercel-ai-gateway/codex` | `openai/gpt-5.5-pro` |
 
 ## Eval structure
 

--- a/experiments/gpt-5.5-pro.ts
+++ b/experiments/gpt-5.5-pro.ts
@@ -1,12 +1,12 @@
 import type { ExperimentConfig } from '@vercel/agent-eval';
 
 const config: ExperimentConfig = {
-  agent: 'codex',
-  model: 'gpt-5.5?reasoningEffort=xhigh',
+  agent: 'vercel-ai-gateway/codex',
+  model: 'openai/gpt-5.5-pro',
   scripts: ['build'],
-  runs: 4,
+  runs: 1,
   earlyExit: true,
-  timeout: 720,
+  timeout: 1800,
   sandbox: 'vercel',
 };
 

--- a/experiments/gpt-5.5-xhigh.ts
+++ b/experiments/gpt-5.5-xhigh.ts
@@ -1,0 +1,13 @@
+import type { ExperimentConfig } from '@vercel/agent-eval';
+
+const config: ExperimentConfig = {
+  agent: 'codex',
+  model: 'gpt-5.5?reasoningEffort=xhigh',
+  scripts: ['build'],
+  runs: 4,
+  earlyExit: true,
+  timeout: 720,
+  sandbox: 'vercel',
+};
+
+export default config;

--- a/scripts/export-results.ts
+++ b/scripts/export-results.ts
@@ -56,7 +56,7 @@ const MODEL_NAMES: Record<string, string> = {
   'devstral-2': 'Devstral 2',
   'gpt-5.3-codex-xhigh': 'GPT 5.3 Codex (xhigh)',
   'gpt-5.4-xhigh': 'GPT 5.4 (xhigh)',
-  'gpt-5.5-xhigh': 'GPT 5.5 (xhigh)',
+  'gpt-5.5-pro': 'GPT 5.5 Pro',
 };
 
 const HARNESS_NAMES: Record<string, string> = {

--- a/scripts/export-results.ts
+++ b/scripts/export-results.ts
@@ -56,6 +56,7 @@ const MODEL_NAMES: Record<string, string> = {
   'devstral-2': 'Devstral 2',
   'gpt-5.3-codex-xhigh': 'GPT 5.3 Codex (xhigh)',
   'gpt-5.4-xhigh': 'GPT 5.4 (xhigh)',
+  'gpt-5.5-xhigh': 'GPT 5.5 (xhigh)',
 };
 
 const HARNESS_NAMES: Record<string, string> = {


### PR DESCRIPTION
Adds a `gpt-5.5-xhigh` experiment using the `codex` agent with `reasoningEffort=xhigh`, matching the existing `gpt-5.4-xhigh` config. Registers it in `scripts/export-results.ts` and the README models table.

> [!NOTE]
> Transparency: this PR was vibecoded — written by an AI agent and only watched over by a human. Flagging so reviewers know to scrutinize accordingly.