### PR TITLE
feat(experiments): add grok-4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Unit tests for the token extraction and pricing in `scripts/cost.ts`.
 | `gpt-5.4-xhigh` | `vercel-ai-gateway/codex` | `openai/gpt-5.4?reasoningEffort=xhigh` |
 | `gpt-5.5-pro` | `vercel-ai-gateway/codex` | `openai/gpt-5.5-pro` |
 | `gpt-5.6-sol-xhigh` | `vercel-ai-gateway/codex` | `openai/gpt-5.6-sol?reasoningEffort=xhigh` |
+| `grok-4.6` | `vercel-ai-gateway/opencode` | `vercel/spacexai/grok-4.6` |
 | `kimi-k2.6` | `vercel-ai-gateway/opencode` | `vercel/moonshotai/kimi-k2.6` |
 | `kimi-k2.7-code` | `vercel-ai-gateway/opencode` | `vercel/moonshotai/kimi-k2.7-code` |
 | `kimi-k3` | `vercel-ai-gateway/opencode` | `vercel/moonshotai/kimi-k3` |

--- a/experiments/grok-4.6.ts
+++ b/experiments/grok-4.6.ts
@@ -1,0 +1,13 @@
+import type { ExperimentConfig } from '@vercel/agent-eval';
+
+const config: ExperimentConfig = {
+  agent: 'vercel-ai-gateway/opencode',
+  model: 'vercel/spacexai/grok-4.6',
+  scripts: ['build'],
+  runs: 4,
+  earlyExit: true,
+  timeout: 1200,
+  sandbox: 'vercel',
+};
+
+export default config;

--- a/scripts/cost.ts
+++ b/scripts/cost.ts
@@ -56,6 +56,7 @@ export const MODEL_PRICING: Record<string, Pricing | null> = {
   'gpt-5.4-xhigh': { input: 2.5, output: 15, cacheRead: 0.25, cacheWrite: 0 },
   'gpt-5.5-pro': { input: 30, output: 180, cacheRead: 0, cacheWrite: 0 }, // never caches; cacheRead moot
   'gpt-5.6-sol-xhigh': { input: 5, output: 30, cacheRead: 0.5, cacheWrite: 6.25 },
+  'grok-4.6': { input: 2, output: 6, cacheRead: 0.5, cacheWrite: 0 },
   'kimi-k2.6': { input: 0.95, output: 4, cacheRead: 0.16, cacheWrite: 0 },
   'kimi-k2.7-code': { input: 0.95, output: 4, cacheRead: 0.19, cacheWrite: 0 },
   'kimi-k3': { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 0 },

--- a/scripts/export-results.ts
+++ b/scripts/export-results.ts
@@ -91,6 +91,7 @@ const MODEL_NAMES: Record<string, string> = {
   'gpt-5.4-xhigh': 'GPT 5.4 (xhigh)',
   'gpt-5.5-pro': 'GPT 5.5 Pro',
   'gpt-5.6-sol-xhigh': 'GPT 5.6 Sol (xhigh)',
+  'grok-4.6': 'Grok 4.6',
   'kimi-k2.6': 'Kimi K2.6',
   'kimi-k2.7-code': 'Kimi K2.7 Code',
   'kimi-k3': 'Kimi K3',


### PR DESCRIPTION
Adds the `grok-4.6` experiment config, its `MODEL_PRICING` entry and its display name.

Draft because I cannot run the evals yet, our team is restricted on the AI Gateway for this model. Results are not included, the leaderboard will not show a `grok-4.6` row until someone runs it.

What is verified locally:

- gateway id is `spacexai/grok-4.6` (the `/v1/models` listing confirms it, `xai/grok-4.6` does not exist)
- pricing matches the gateway listing exactly: `$2` in, `$6` out, `$0.5` cache read, no cache write
- `vercel/spacexai/grok-4.6` is catalogued in models.dev, so opencode resolves it without a `binaryUrl` pin
- `npm run test:cost` passes, including the every-experiment-has-pricing check
- `tsc --noEmit` is clean
- `npx agent-eval --dry grok-4.6` resolves to 30 evals x 4 runs with the right agent, model and sandbox

Config mirrors the other opencode experiments: 4 runs, early exit, 1200s timeout, vercel sandbox.